### PR TITLE
Fix \mess not being able to accept some commands

### DIFF
--- a/tex/latex/pgf-umlsd/pgf-umlsd.sty
+++ b/tex/latex/pgf-umlsd/pgf-umlsd.sty
@@ -263,8 +263,7 @@ node
   \addtocounter{seqlevel}{#1}
   \path
   (#4)+(0,-\theseqlevel*\unitfactor-0.7*\unitfactor) node (mess to) {};
-  \draw[->,>=angle 60] (mess from) -- (mess to) node[midway, above]
-  {#3};
+  \draw[->,>=angle 60] (mess from) -- (mess to) node[midway, above] {#3};
 
   \node (#3 from) at (mess from) {};
   \node (#3 to) at (mess to) {};


### PR DESCRIPTION
The newline between \node and node text in \messanother prevented TikZ parsing tricks that suspend command evalutation from working.

In my use case, \ref inside \mess broke horribly,while working fine in messcall and call.