### PR TITLE
Fix text decorations in mess

### DIFF
--- a/tex/latex/pgf-umlsd/pgf-umlsd.sty
+++ b/tex/latex/pgf-umlsd/pgf-umlsd.sty
@@ -265,9 +265,6 @@ node
   (#4)+(0,-\theseqlevel*\unitfactor-0.7*\unitfactor) node (mess to) {};
   \draw[->,>=angle 60] (mess from) -- (mess to) node[midway, above]
   {#3};
-
-  \node (#3 from) at (mess from) {};
-  \node (#3 to) at (mess to) {};
 }
 
 \newenvironment{messcall}[4][1]{


### PR DESCRIPTION
Text decorations are not possible with mess. This fix resolves this. I have not been able to find a place where the named node is used.